### PR TITLE
feat: change validator proto to adapt to greenfield

### DIFF
--- a/cometbft/src/validator.rs
+++ b/cometbft/src/validator.rs
@@ -163,6 +163,10 @@ pub struct Info {
     /// Validator proposer priority
     #[serde(skip)]
     pub proposer_priority: ProposerPriority,
+
+    pub bls_key: account::BLSKey,
+
+    pub relayer_address: account::Id,
 }
 
 impl Info {
@@ -190,6 +194,22 @@ impl Info {
             power: vp,
             name: None,
             proposer_priority: ProposerPriority::default(),
+            bls_key: account::BLSKey::default(),
+            relayer_address: account::Id::from(PublicKey::from_raw_ed25519(&[0u8; 32]).unwrap()),
+        }
+    }
+
+    #[cfg(feature = "rust-crypto")]
+    /// Create a new validator.
+    pub fn new_with_bls_and_relayer(pk: PublicKey, vp: vote::Power, bls_key: Vec<u8>, relayer_address: Vec<u8>) -> Info {
+        Info {
+            address: account::Id::from(pk),
+            pub_key: pk,
+            power: vp,
+            name: None,
+            proposer_priority: ProposerPriority::default(),
+            bls_key: account::BLSKey::try_from(bls_key).unwrap(),
+            relayer_address: account::Id::try_from(relayer_address).unwrap(),
         }
     }
 }
@@ -205,6 +225,10 @@ pub struct SimpleValidator {
     pub pub_key: PublicKey,
     /// Voting power
     pub voting_power: vote::Power,
+    // Bls key
+    pub bls_key: account::BLSKey,
+    // Relayer address
+    pub relayer_address: account::Id,
 }
 
 /// Info -> SimpleValidator
@@ -213,6 +237,8 @@ impl From<&Info> for SimpleValidator {
         SimpleValidator {
             pub_key: info.pub_key,
             voting_power: info.power,
+            bls_key: info.bls_key,
+            relayer_address: info.relayer_address,
         }
     }
 }
@@ -320,6 +346,8 @@ mod v1 {
                 power: value.voting_power.try_into()?,
                 name: None,
                 proposer_priority: value.proposer_priority.into(),
+                bls_key: value.bls_key.try_into()?,
+                relayer_address: value.relayer_address.try_into()?,
             })
         }
     }
@@ -331,6 +359,8 @@ mod v1 {
                 pub_key: Some(value.pub_key.into()),
                 voting_power: value.power.into(),
                 proposer_priority: value.proposer_priority.into(),
+                bls_key: value.bls_key.into(),
+                relayer_address: value.relayer_address.into(),
             }
         }
     }
@@ -347,6 +377,8 @@ mod v1 {
                     .ok_or_else(Error::missing_public_key)?
                     .try_into()?,
                 voting_power: value.voting_power.try_into()?,
+                bls_key: value.bls_key.try_into()?,
+                relayer_address: value.relayer_address.try_into()?,
             })
         }
     }
@@ -356,6 +388,8 @@ mod v1 {
             RawSimpleValidator {
                 pub_key: Some(value.pub_key.into()),
                 voting_power: value.voting_power.into(),
+                bls_key: value.bls_key.into(),
+                relayer_address: value.relayer_address.into(),
             }
         }
     }
@@ -437,6 +471,8 @@ mod v1beta1 {
                 power: value.voting_power.try_into()?,
                 name: None,
                 proposer_priority: value.proposer_priority.into(),
+                bls_key: value.bls_key.try_into()?,
+                relayer_address: value.relayer_address.try_into()?,
             })
         }
     }
@@ -448,6 +484,8 @@ mod v1beta1 {
                 pub_key: Some(value.pub_key.into()),
                 voting_power: value.power.into(),
                 proposer_priority: value.proposer_priority.into(),
+                bls_key: value.bls_key.into(),
+                relayer_address: value.relayer_address.into(),
             }
         }
     }
@@ -464,6 +502,8 @@ mod v1beta1 {
                     .ok_or_else(Error::missing_public_key)?
                     .try_into()?,
                 voting_power: value.voting_power.try_into()?,
+                bls_key: value.bls_key.try_into()?,
+                relayer_address: value.relayer_address.try_into()?,
             })
         }
     }
@@ -473,6 +513,8 @@ mod v1beta1 {
             RawSimpleValidator {
                 pub_key: Some(value.pub_key.into()),
                 voting_power: value.voting_power.into(),
+                bls_key: value.bls_key.into(),
+                relayer_address: value.relayer_address.into(),
             }
         }
     }

--- a/proto/src/prost/cometbft.types.v1.rs
+++ b/proto/src/prost/cometbft.types.v1.rs
@@ -127,10 +127,17 @@ pub struct Validator {
     #[serde(with = "crate::serializers::from_str_allow_null")]
     #[serde(default)]
     pub proposer_priority: i64,
+    #[prost(bytes = "vec", tag = "5")]
+    #[serde(with = "crate::serializers::bytes::hexstring")]
+    pub bls_key: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "6")]
+    #[serde(with = "crate::serializers::bytes::hexstring")]
+    pub relayer_address: ::prost::alloc::vec::Vec<u8>,
 }
 /// SimpleValidator is a Validator, which is serialized and hashed in consensus.
 /// Address is removed because it's redundant with the pubkey.
 /// Proposer priority is removed because it changes every round.
+#[derive(::serde::Deserialize, ::serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SimpleValidator {
@@ -138,6 +145,12 @@ pub struct SimpleValidator {
     pub pub_key: ::core::option::Option<super::super::crypto::v1::PublicKey>,
     #[prost(int64, tag = "2")]
     pub voting_power: i64,
+    #[serde(with = "crate::serializers::bytes::hexstring")]
+    #[prost(bytes = "vec", tag = "3")]
+    pub bls_key: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "4")]
+    #[serde(with = "crate::serializers::bytes::hexstring")]
+    pub relayer_address: ::prost::alloc::vec::Vec<u8>,
 }
 /// BlockIdFlag indicates which BlockID the signature is for
 #[derive(::num_derive::FromPrimitive, ::num_derive::ToPrimitive)]

--- a/proto/src/prost/cometbft.types.v1beta1.rs
+++ b/proto/src/prost/cometbft.types.v1beta1.rs
@@ -115,10 +115,17 @@ pub struct Validator {
     #[serde(with = "crate::serializers::from_str_allow_null")]
     #[serde(default)]
     pub proposer_priority: i64,
+    #[prost(bytes = "vec", tag = "5")]
+    #[serde(with = "crate::serializers::bytes::hexstring")]
+    pub bls_key: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "6")]
+    #[serde(with = "crate::serializers::bytes::hexstring")]
+    pub relayer_address: ::prost::alloc::vec::Vec<u8>,
 }
 /// SimpleValidator is a Validator, which is serialized and hashed in consensus.
 /// Address is removed because it's redundant with the pubkey.
 /// Proposer priority is removed because it changes every round.
+#[derive(::serde::Deserialize, ::serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SimpleValidator {
@@ -126,6 +133,12 @@ pub struct SimpleValidator {
     pub pub_key: ::core::option::Option<super::super::crypto::v1::PublicKey>,
     #[prost(int64, tag = "2")]
     pub voting_power: i64,
+    #[serde(with = "crate::serializers::bytes::hexstring")]
+    #[prost(bytes = "vec", tag = "3")]
+    pub bls_key: ::prost::alloc::vec::Vec<u8>,
+    #[prost(bytes = "vec", tag = "4")]
+    #[serde(with = "crate::serializers::bytes::hexstring")]
+    pub relayer_address: ::prost::alloc::vec::Vec<u8>,
 }
 /// BlockIdFlag indicates which BlockID the signature is for
 #[derive(::num_derive::FromPrimitive, ::num_derive::ToPrimitive)]


### PR DESCRIPTION
## Description

This is to adapt to greenfield-cometbft's new bls_key and relayer_address fields for the validator.

`reth/revm` needs to use light header verification.