### PR TITLE
Set Optional of dependencies futures

### DIFF
--- a/cometbft/Cargo.toml
+++ b/cometbft/Cargo.toml
@@ -32,7 +32,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 bytes = { version = "1.2", default-features = false, features = ["serde"] }
 digest = { version = "0.10", default-features = false }
 ed25519 = { version = "2", default-features = false, features = ["alloc"] }
-futures = { version = "0.3", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 once_cell = { version = "1.3", default-features = false }
 prost = { version = "0.12", default-features = false }

--- a/light-client/Cargo.toml
+++ b/light-client/Cargo.toml
@@ -42,7 +42,6 @@ cometbft-light-client-verifier = { version = "0.1.0-alpha.2", path = "../light-c
 contracts = { version = "0.6.2", default-features = false }
 crossbeam-channel = { version = "0.5.11", default-features = false, features = ["std"] }
 derive_more = { version = "0.99.5", default-features = false, features = ["display"] }
-futures = { version = "0.3.4", default-features = false }
 serde = { version = "1.0.106", default-features = false }
 serde_cbor = { version = "0.11.1", default-features = false, features = ["alloc", "std"] }
 serde_derive = { version = "1.0.106", default-features = false }


### PR DESCRIPTION
### Description

Set Optional of dependencies futures

### Rationale

 in order to be sp1 compatible for opbnb

### Changes

set futures dependencies to be optional
